### PR TITLE
Add 74-ruby.zsh conf.d module for rbenv init

### DIFF
--- a/home/dot_config/zsh/conf.d/74-ruby.zsh
+++ b/home/dot_config/zsh/conf.d/74-ruby.zsh
@@ -1,0 +1,8 @@
+# Ruby via rbenv.
+
+export RBENV_ROOT="$HOME/.rbenv"
+[[ -d "$RBENV_ROOT/bin" ]] && path=("$RBENV_ROOT/bin" $path)
+
+if (( $+commands[rbenv] )); then
+  eval "$(rbenv init - zsh)"
+fi


### PR DESCRIPTION
## Summary
The zsh migration ported node (nvm→fnm), python, java, and go into `~/.config/zsh/conf.d/` but missed Ruby. On machines that use **rbenv**, applying the new `~/.zshrc` silently dropped `rbenv init`, so `ruby`/gem shims disappeared from new shells.

This adds a guarded `74-ruby.zsh` module matching the existing `70-73` tool-initializer pattern:

```zsh
if (( $+commands[rbenv] )); then
  eval "$(rbenv init - zsh)"
fi
```

## Context
Surfaced while making chezmoi own `~/.zshrc` on macOS: the live `~/.zshrc` was still the pre-migration file (sourcing a now-deleted `configuration/bash/bashrc`), and a full `chezmoi apply` had never completed. After `chezmoi apply ~/.zshrc ~/.config/zsh`, rbenv was the only regression vs. the old hand-written rc — this module closes that gap.

## Test plan
- `command -v rbenv` present → new interactive shell initializes rbenv; `ruby` resolves to `~/.rbenv/shims/ruby`.
- `command -v rbenv` absent → module no-ops (no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)