### PR TITLE
Add gcloud install for Linux via Google's apt repo

### DIFF
--- a/home/run_once_after_22-install-gcloud-linux.sh.tmpl
+++ b/home/run_once_after_22-install-gcloud-linux.sh.tmpl
@@ -1,0 +1,57 @@
+{{ if eq .chezmoi.os "linux" -}}
+#!/usr/bin/env bash
+# Install the Google Cloud CLI on Linux from Google's official apt repo. macOS gets gcloud
+# via the google-cloud-sdk Homebrew cask (see packages.yaml); brew has no Linux equivalent,
+# so we wire up the apt source here. Installs to /usr/lib/google-cloud-sdk, which the
+# 80-gcloud.zsh.tmpl shell module already sources. Idempotent and non-fatal: a locked-down
+# workstation may disallow apt-repo changes, so we warn rather than fail `chezmoi apply`.
+set -uo pipefail
+
+if command -v gcloud >/dev/null 2>&1; then
+  exit 0
+fi
+
+{{ if has .chezmoi.osRelease.id (list "debian" "ubuntu" "pop" "linuxmint") -}}
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "WARN: apt-get not found; skipping gcloud install" >&2
+  exit 0
+fi
+
+KEYRING="/usr/share/keyrings/cloud.google.gpg"
+SOURCE_LIST="/etc/apt/sources.list.d/google-cloud-sdk.list"
+
+echo "==> Installing Google Cloud CLI (apt)"
+
+sudo apt-get install -y apt-transport-https ca-certificates gnupg curl || {
+  echo "WARN: could not install gcloud apt prerequisites; skipping" >&2
+  exit 0
+}
+
+# Fetch and dearmor Google's signing key into a dedicated keyring.
+if [ ! -f "$KEYRING" ]; then
+  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | sudo gpg --dearmor -o "$KEYRING" || {
+      echo "WARN: could not install Google apt signing key; skipping gcloud install" >&2
+      exit 0
+    }
+fi
+
+# Register the cloud-sdk apt source, pinned to the keyring above.
+if [ ! -f "$SOURCE_LIST" ]; then
+  echo "deb [signed-by=$KEYRING] https://packages.cloud.google.com/apt cloud-sdk main" \
+    | sudo tee "$SOURCE_LIST" >/dev/null || {
+      echo "WARN: could not write $SOURCE_LIST; skipping gcloud install" >&2
+      exit 0
+    }
+fi
+
+sudo apt-get update -y || echo "WARN: apt-get update failed; continuing" >&2
+if sudo apt-get install -y google-cloud-cli; then
+  echo "==> Google Cloud CLI installed (open a new shell for gcloud on PATH)"
+else
+  echo "WARN: google-cloud-cli install failed" >&2
+fi
+{{ else -}}
+echo "WARN: unsupported Linux distro '{{ .chezmoi.osRelease.id }}'; skipping gcloud install" >&2
+{{ end -}}
+{{ end -}}

--- a/home/run_once_after_22-install-gcloud-linux.sh.tmpl
+++ b/home/run_once_after_22-install-gcloud-linux.sh.tmpl
@@ -27,13 +27,24 @@ sudo apt-get install -y apt-transport-https ca-certificates gnupg curl || {
   exit 0
 }
 
-# Fetch and dearmor Google's signing key into a dedicated keyring.
+# Fetch and dearmor Google's signing key into a dedicated keyring. Stage in a temp file and
+# install atomically so a failed download can't leave a partial keyring that the guard above
+# would then trust on the next run, permanently breaking apt with a bad-signature error.
 if [ ! -f "$KEYRING" ]; then
-  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    | sudo gpg --dearmor -o "$KEYRING" || {
+  _key_tmp="$(mktemp)"
+  if curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+       | gpg --dearmor -o "$_key_tmp"; then
+    sudo install -m 0644 "$_key_tmp" "$KEYRING" || {
       echo "WARN: could not install Google apt signing key; skipping gcloud install" >&2
+      rm -f "$_key_tmp"
       exit 0
     }
+  else
+    echo "WARN: could not fetch Google apt signing key; skipping gcloud install" >&2
+    rm -f "$_key_tmp"
+    exit 0
+  fi
+  rm -f "$_key_tmp"
 fi
 
 # Register the cloud-sdk apt source, pinned to the keyring above.


### PR DESCRIPTION
## What

Adds `home/run_once_after_22-install-gcloud-linux.sh.tmpl` — installs the Google Cloud CLI on Debian-family Linux from Google's official apt repo.

## Why

gcloud was only set up for macOS: the `google-cloud-sdk` Homebrew **cask** in `packages.yaml`, sourced by the existing `80-gcloud.zsh.tmpl` shell module. That cask is macOS-only and has no Homebrew-on-Linux equivalent, so Linux machines had no gcloud despite the shell module already supporting the Linux install paths (`/usr/lib/google-cloud-sdk`, `$HOME/google-cloud-sdk`).

## How

The new `run_once_after` script:
- Registers Google's signing key at `/usr/share/keyrings/cloud.google.gpg` and the `cloud-sdk` apt source, then installs `google-cloud-cli` → lands in `/usr/lib/google-cloud-sdk`, exactly the path `80-gcloud.zsh.tmpl` already sources.
- Follows existing repo conventions: `{{ if eq .chezmoi.os "linux" }}` guard, the same `debian/ubuntu/pop/linuxmint` distro check as the main installer, `set -uo pipefail`, and warn-don't-fail behavior for locked-down workstations.
- Is idempotent: early-exits if `gcloud` is already on PATH, and skips re-adding the key/source if present.

Deliberately **not** added to `packages.linux.apt`: that list is consumed by `run_onchange_before_00-install-packages-linux`, which runs *before* this script — so the Google repo wouldn't exist yet and the install would fail. The dedicated `run_once_after` script is the correct ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)