### PR TITLE
Use rv instead of rbenv for Ruby version management

### DIFF
--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -28,6 +28,7 @@ packages:
       - git-delta
       - openjdk
       - pyenv
+      - rv
       - starship
       - awscli
       - hashicorp/tap/terraform
@@ -56,6 +57,7 @@ packages:
       - fnm
       - git-delta
       - pyenv
+      - rv
       - starship
       - awscli
       - hashicorp/tap/terraform

--- a/home/dot_config/zsh/conf.d/74-ruby.zsh
+++ b/home/dot_config/zsh/conf.d/74-ruby.zsh
@@ -1,8 +1,8 @@
-# Ruby via rbenv.
+# Ruby via rv (spinel-coop) — fast, single-binary version + gem manager. Replaces rbenv.
+# rv is installed onto PATH by the package step; `rv shell init` registers a preexec
+# hook that switches Ruby per .ruby-version/.tool-versions. Completions come from
+# Homebrew's site-functions via compinit (see 30-completion.zsh), so none are sourced here.
 
-export RBENV_ROOT="$HOME/.rbenv"
-[[ -d "$RBENV_ROOT/bin" ]] && path=("$RBENV_ROOT/bin" $path)
-
-if (( $+commands[rbenv] )); then
-  eval "$(rbenv init - zsh)"
+if (( $+commands[rv] )); then
+  eval "$(rv shell init zsh)"
 fi


### PR DESCRIPTION
## Summary
Replaces rbenv with **[rv](https://github.com/spinel-coop/rv)** (spinel-coop) as the Ruby version + gem manager. rv is a fast, single-binary Rust tool — consistent with this repo's existing choice of `fnm` over `nvm` for Node.

Follow-up to #11 (which added the rbenv module); this swaps the implementation to rv.

## Changes
- **`packages.yaml`**: add `rv` to the brew lists (darwin + linux), alphabetically after `pyenv`, so it installs with everything else. (rbenv was never in the manifest — it had been installed manually.)
- **`74-ruby.zsh`**: guard on `rv` being present, then `eval "$(rv shell init zsh)"`. rv registers a `preexec` hook that switches Ruby per `.ruby-version` / `.tool-versions`. No shims — rv is PATH-based. Completions come from Homebrew's `site-functions` via `compinit` (see `30-completion.zsh`), so none are sourced in the module.

## Why rv over rbenv
rbenv is mature but uses a shim layer and adds shell-startup cost; the 2026 ecosystem has moved toward faster Rust-based managers. rv installs precompiled rubies in seconds and reads the standard `.ruby-version` format, so existing projects work unchanged.

## Migration note
rv manages its own rubies — it won't reuse the existing `~/.rbenv` versions. After this lands: `chezmoi apply`, then install a Ruby with rv (e.g. `rv ruby install`), and the `~/.zshrc.local` rbenv bridge can be removed.

## Test plan
- `rv` present → new interactive shell runs `rv shell init`; Ruby resolves per `.ruby-version`.
- `rv` absent → module no-ops (guarded), no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)