### PR TITLE
Rename google-cloud-sdk cask to gcloud-cli

### DIFF
--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -34,11 +34,11 @@ packages:
       - awscli
       - hashicorp/tap/terraform
       - pulumi/tap/pulumi
-      # google-cloud-sdk + ghostty are casks (see below) but listed via brew bundle too
+      # gcloud-cli + ghostty are casks (see below) but listed via brew bundle too
     # Homebrew casks (GUI / large vendored apps)
     cask:
       - ghostty
-      - google-cloud-sdk
+      - gcloud-cli
       - hammerspoon
       - font-jetbrains-mono-nerd-font
 

--- a/home/dot_config/zsh/conf.d/80-gcloud.zsh.tmpl
+++ b/home/dot_config/zsh/conf.d/80-gcloud.zsh.tmpl
@@ -4,7 +4,9 @@
 _gcloud_candidates=(
 {{ if eq .chezmoi.os "darwin" -}}
   "${HOMEBREW_PREFIX:-/opt/homebrew}/share/google-cloud-sdk"
-  "${HOMEBREW_PREFIX:-/opt/homebrew}/Caskroom/google-cloud-sdk/latest/google-cloud-sdk"
+  # gcloud-cli is a versioned cask (Caskroom/gcloud-cli/<version>/…); (N) drops the
+  # glob if nothing matches. The share/ path above is the usual hit; this is a fallback.
+  ${HOMEBREW_PREFIX:-/opt/homebrew}/Caskroom/gcloud-cli/*/google-cloud-sdk(N)
 {{ end -}}
   "$HOME/google-cloud-sdk"
   "$HOME/workspace/google-cloud-sdk"


### PR DESCRIPTION
## Summary
Homebrew renamed the `google-cloud-sdk` cask to **`gcloud-cli`**, so `brew bundle` printed a deprecation warning on every package run. This renames it in the manifest and fixes the one ripple effect.

## Changes
- **`packages.yaml`**: rename the cask `google-cloud-sdk` → `gcloud-cli` (and the explanatory comment).
- **`80-gcloud.zsh`**: the old cask was a `:latest` cask (`Caskroom/google-cloud-sdk/latest/…`); `gcloud-cli` is **versioned** (`Caskroom/gcloud-cli/<version>/…`). Updated the Caskroom fallback candidate to glob the version dir with the `(N)` nullglob qualifier so it resolves (or safely drops) regardless of version. The primary `share/google-cloud-sdk` candidate is unchanged by the rename and still resolves first.

## Verification
- `brew info --cask gcloud-cli` → installed at `Caskroom/gcloud-cli/573.0.0`; SDK still at `share/google-cloud-sdk`.
- Simulated the rendered darwin module: resolves to `share/google-cloud-sdk` (path.zsh.inc present); the new glob expands to the versioned Caskroom dirs.
- `packages.yaml` parses as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)