### PR TITLE
Speed up starship Python detection to stop prompt timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # chezmoi local state (should never be committed)
 home/.chezmoi.toml
+
+# Locally downloaded binaries (e.g. chezmoi)
+bin/

--- a/home/dot_config/starship.toml
+++ b/home/dot_config/starship.toml
@@ -1,8 +1,10 @@
 # Starship prompt. Minimal, fast, legible in a 256-colour terminal (ghostty).
 # https://starship.rs/config/
 
+# command_timeout is a safety backstop: the pyenv-based Python lookup below can
+# spike past the default on cold/contended renders (e.g. first prompt after cd).
 add_newline = true
-command_timeout = 1000
+command_timeout = 2000
 
 format = """
 $directory\
@@ -36,8 +38,12 @@ min_time = 2000
 format = "[$duration]($style) "
 
 # Language modules: only show inside relevant projects (default behaviour).
+# Read the version from pyenv (`pyenv version-name`, ~95ms) instead of executing
+# the pyenv `python` shim (~210ms + interpreter startup), which intermittently
+# timed out the prompt render in pyenv-managed projects.
 [python]
 symbol = " "
+pyenv_version_name = true
 [nodejs]
 symbol = " "
 [golang]

--- a/home/dot_config/starship.toml.tmpl
+++ b/home/dot_config/starship.toml.tmpl
@@ -1,8 +1,8 @@
 # Starship prompt. Minimal, fast, legible in a 256-colour terminal (ghostty).
 # https://starship.rs/config/
 
-# command_timeout is a safety backstop: the pyenv-based Python lookup below can
-# spike past the default on cold/contended renders (e.g. first prompt after cd).
+# command_timeout is a safety backstop: the per-language version lookups below
+# can spike past the default on cold/contended renders (e.g. first prompt after cd).
 add_newline = true
 command_timeout = 2000
 
@@ -38,12 +38,16 @@ min_time = 2000
 format = "[$duration]($style) "
 
 # Language modules: only show inside relevant projects (default behaviour).
-# Read the version from pyenv (`pyenv version-name`, ~95ms) instead of executing
-# the pyenv `python` shim (~210ms + interpreter startup), which intermittently
-# timed out the prompt render in pyenv-managed projects.
 [python]
 symbol = " "
+{{- if lookPath "pyenv" }}
+# On pyenv hosts, read the version from pyenv (`pyenv version-name`, ~95ms)
+# instead of executing the pyenv `python` shim (~210ms + interpreter startup),
+# which intermittently timed out the prompt render in pyenv-managed projects.
+# Gated on pyenv being installed: without it `pyenv version-name` returns
+# nothing and the prompt would show an empty Python version.
 pyenv_version_name = true
+{{- end }}
 [nodejs]
 symbol = " "
 [golang]


### PR DESCRIPTION
## Problem

`cd` into a pyenv-managed project (e.g. `~/workspace/email-agent`) intermittently emitted:

```
[WARN] - (starship::utils): Executing command "/Users/adamtait/.pyenv/shims/python" timed out.
```

### Root cause

starship's `[python]` module shows the version by **executing the `python` binary**. On PATH that's the pyenv **shim**, which doesn't run Python directly — it re-execs `pyenv exec python`: bash startup → pyenv version resolution → real CPython interpreter startup (~210ms steady state). On cold/contended renders (first prompt after a `cd`, with git modules + disk I/O competing) this spikes past `command_timeout`, so starship aborts the module, logs the WARN, and drops the Python segment.

## Fix

- `pyenv_version_name = true` — starship reads the version via `pyenv version-name` (~95ms, no interpreter startup) instead of running the shim.
- `command_timeout` 1000 → 2000 — backstop for the remaining cold-spike tail.

## Testing

In `~/workspace/email-agent` with the new config:
- `starship timings`: python module **210ms → 89ms**
- `starship explain`: `via  pyenv 3.12.13` (version still displays correctly)
- repeated `starship prompt` renders: **no timeout warnings**

## Apply note

This is the chezmoi dev checkout (`~/.dotfiles`). After merge, the change reaches the live source (`~/.local/share/chezmoi`) and `chezmoi apply` before it affects the live `~/.config/starship.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)