### PR TITLE
Fix Linux package install: correct apt names + per-package install

### DIFF
--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -5,12 +5,9 @@ packages:
   # Installed on every OS (names valid for both brew and apt where they overlap).
   common:
     - bat
-    - emacs
-    - fd
     - fzf
     - gh
     - git
-    - go
     - htop
     - jq
     - ncdu
@@ -24,8 +21,11 @@ packages:
     brew:
       - clojure/tools/clojure
       - coreutils
+      - emacs
+      - fd
       - fnm
       - git-delta
+      - go
       - jj
       - openjdk
       - pyenv
@@ -48,6 +48,7 @@ packages:
       - build-essential
       - curl
       - emacs-nox
+      - fd-find
       - fonts-jetbrains-mono
       - golang-go
       - openjdk-21-jdk

--- a/home/run_onchange_before_00-install-packages-linux.sh.tmpl
+++ b/home/run_onchange_before_00-install-packages-linux.sh.tmpl
@@ -18,9 +18,12 @@ APT_PACKAGES=(
 if command -v apt-get >/dev/null 2>&1; then
   echo "==> apt-get install ${APT_PACKAGES[*]}"
   sudo apt-get update -y
-  # Some "common" names differ on apt; install best-effort and don't abort the whole run.
-  sudo apt-get install -y "${APT_PACKAGES[@]}" || \
-    echo "WARN: some apt packages failed; continuing" >&2
+  # Install individually: apt-get is atomic, so a single unknown name would abort
+  # the whole batch and install nothing. Per-package keeps a bad name isolated and
+  # the failure visible instead of silently dropping everything (e.g. emacs-nox).
+  for p in "${APT_PACKAGES[@]}"; do
+    sudo apt-get install -y "$p" || echo "WARN: apt package '$p' failed; continuing" >&2
+  done
 fi
 {{ else -}}
 echo "WARN: unsupported Linux distro '{{ .chezmoi.osRelease.id }}'; skipping apt step" >&2


### PR DESCRIPTION
## Problem
`chezmoi apply` on the Linux cloud-workstation installed **nothing** from apt — including `emacs-nox` — leaving the `WARN: emacs not found; skipping package pre-install` you saw later in the run.

Root cause: the apt list (built from `packages.common` + `packages.linux.apt`) contained two names that don't exist on apt:

- `fd` → the apt package is **`fd-find`**
- `go` → there is no apt package `go` (Go ships as **`golang-go`**, already listed)

`apt-get install` is **atomic** — one unknown name aborts the entire transaction and installs nothing. The `|| echo WARN` then swallowed the error, so the run continued to Homebrew (awscli/terraform/pulumi installed fine) and the failure was invisible.

```
$ apt-get install -y --simulate ... fd ... go ...
E: Unable to locate package fd
E: Unable to locate package go
exit: 100
```

## Fix
- Drop `emacs`, `fd`, `go` from `packages.common` (not portable apt names). Move `emacs`/`fd`/`go` to `darwin.brew`; add `fd-find` to `linux.apt`. `emacs-nox` and `golang-go` already cover emacs/Go on Linux.
- Install apt packages **one at a time** so a single bad name can't abort the batch again, and any failure is reported per-package.

## Note
This unblocks the apt step, but on this workstation emacs install is *also* blocked at the dpkg level by a malformed `/etc/environment` (the `install-info` trigger shell-sources it and chokes on an unquoted `|`). That's a separate, upstream (remote-agent) fix — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)