### PR TITLE
chore(ra): sync snapshot with shared ra-env helper refactor

### DIFF
--- a/home/dot_config/ra/plugins/private_claude/workstation-startup.d/executable_260_claude-setup.sh
+++ b/home/dot_config/ra/plugins/private_claude/workstation-startup.d/executable_260_claude-setup.sh
@@ -22,14 +22,35 @@ CLAUDE_BIN_PATH="${USER_HOME}/.npm-global/bin/claude"
 
 log() { echo "[claude-setup] $(date -u +%H:%M:%S) $*"; }
 
+# Source the shared ra-env helper (ra_env_set / ra_env_unset), installed by
+# 200_remote-agent-setup.sh at boot. Each function dedups and updates BOTH
+# /etc/environment and /run/ra/env. Fall back to a thin inline implementation
+# if the lib is missing (e.g. a newer plugin booting against an older core).
+if [ -r /usr/local/lib/ra/ra-env.sh ]; then
+    # shellcheck source=/dev/null
+    . /usr/local/lib/ra/ra-env.sh
+else
+    log "WARNING: /usr/local/lib/ra/ra-env.sh missing; using inline fallback"
+    ra_env_set() {
+        local key="$1" val="$2"
+        [ -f /etc/environment ] || : > /etc/environment
+        sed -i "/^${key}=/d" /etc/environment
+        echo "${key}=${val}" >> /etc/environment
+    }
+    ra_env_unset() {
+        local key="$1"
+        [ -f /etc/environment ] && sed -i "/^${key}=/d" /etc/environment
+        [ -f /run/ra/env ] && sed -i "/^${key}=/d" /run/ra/env
+        return 0
+    }
+fi
+
 _clear_stale_state() {
     rm -f "${APIKEY_HELPER_PATH}"
-    # Guard the seds: `sed -i` on a not-yet-created /etc/environment fails and,
-    # under `set -e`, would abort the whole setup before auth is configured.
-    if [ -f /etc/environment ]; then
-        sed -i '/^CLAUDE_CODE_OAUTH_TOKEN=/d' /etc/environment
-        sed -i '/^ANTHROPIC_API_KEY=/d' /etc/environment
-    fi
+    # Clear prior auth from BOTH /etc/environment and /run/ra/env so a provider
+    # switch can't leave a stale token where login shells still source it.
+    ra_env_unset CLAUDE_CODE_OAUTH_TOKEN
+    ra_env_unset ANTHROPIC_API_KEY
 
     if [[ -f "${CLAUDE_SETTINGS_PATH}" ]] && command -v jq >/dev/null 2>&1; then
         if jq -e '.apiKeyHelper' "${CLAUDE_SETTINGS_PATH}" >/dev/null 2>&1; then
@@ -87,7 +108,7 @@ case "${RA_PLUGIN_CLAUDE_AUTH_PROVIDER:-}" in
         if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
             log "CLAUDE_CODE_OAUTH_TOKEN not set; auth may fail"
         else
-            echo "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}" >> /etc/environment
+            ra_env_set CLAUDE_CODE_OAUTH_TOKEN "${CLAUDE_CODE_OAUTH_TOKEN}"
             log "exported CLAUDE_CODE_OAUTH_TOKEN"
             _seed_onboarding "${CLAUDE_CODE_OAUTH_TOKEN}"
         fi

--- a/home/dot_config/ra/plugins/private_claude/workstation-startup.d/executable_260_claude-setup.sh
+++ b/home/dot_config/ra/plugins/private_claude/workstation-startup.d/executable_260_claude-setup.sh
@@ -23,24 +23,35 @@ CLAUDE_BIN_PATH="${USER_HOME}/.npm-global/bin/claude"
 log() { echo "[claude-setup] $(date -u +%H:%M:%S) $*"; }
 
 # Source the shared ra-env helper (ra_env_set / ra_env_unset), installed by
-# 200_remote-agent-setup.sh at boot. Each function dedups and updates BOTH
-# /etc/environment and /run/ra/env. Fall back to a thin inline implementation
-# if the lib is missing (e.g. a newer plugin booting against an older core).
+# 200_remote-agent-setup.sh at boot. Each updates BOTH /etc/environment and
+# /run/ra/env, deduped. If the lib is somehow absent (e.g. a newer plugin
+# booting against an older core that predates it), fall back to an inline copy
+# with the SAME both-file contract — so behavior is identical whether or not the
+# lib is present, rather than silently diverging.
 if [ -r /usr/local/lib/ra/ra-env.sh ]; then
     # shellcheck source=/dev/null
     . /usr/local/lib/ra/ra-env.sh
 else
     log "WARNING: /usr/local/lib/ra/ra-env.sh missing; using inline fallback"
+    : "${RA_ENV_FILE:=/run/ra/env}"
     ra_env_set() {
         local key="$1" val="$2"
         [ -f /etc/environment ] || : > /etc/environment
         sed -i "/^${key}=/d" /etc/environment
         echo "${key}=${val}" >> /etc/environment
+        if [ ! -f "${RA_ENV_FILE}" ]; then
+            ( umask 077; : > "${RA_ENV_FILE}" )
+            chown user:user "${RA_ENV_FILE}"
+            chmod 0600 "${RA_ENV_FILE}"
+        fi
+        sed -i "/^${key}=/d" "${RA_ENV_FILE}"
+        local quoted="${val//\'/\'\\\'\'}"
+        printf "%s='%s'\n" "${key}" "${quoted}" >> "${RA_ENV_FILE}"
     }
     ra_env_unset() {
         local key="$1"
         [ -f /etc/environment ] && sed -i "/^${key}=/d" /etc/environment
-        [ -f /run/ra/env ] && sed -i "/^${key}=/d" /run/ra/env
+        [ -f "${RA_ENV_FILE}" ] && sed -i "/^${key}=/d" "${RA_ENV_FILE}"
         return 0
     }
 fi

--- a/home/dot_config/ra/plugins/private_codex/workstation-startup.d/executable_260_codex-setup.sh
+++ b/home/dot_config/ra/plugins/private_codex/workstation-startup.d/executable_260_codex-setup.sh
@@ -25,17 +25,37 @@ AUTH_FILE="${CODEX_HOME}/auth.json"
 
 log() { echo "[codex-setup] $(date -u +%H:%M:%S) $*"; }
 
+# Source the shared ra-env helper (ra_env_set / ra_env_unset), installed by
+# 200_remote-agent-setup.sh at boot. Each function dedups and updates BOTH
+# /etc/environment and /run/ra/env. Fall back to a thin inline implementation
+# if the lib is missing (e.g. a newer plugin booting against an older core).
+if [ -r /usr/local/lib/ra/ra-env.sh ]; then
+    # shellcheck source=/dev/null
+    . /usr/local/lib/ra/ra-env.sh
+else
+    log "WARNING: /usr/local/lib/ra/ra-env.sh missing; using inline fallback"
+    ra_env_set() {
+        local key="$1" val="$2"
+        [ -f /etc/environment ] || : > /etc/environment
+        sed -i "/^${key}=/d" /etc/environment
+        echo "${key}=${val}" >> /etc/environment
+    }
+    ra_env_unset() {
+        local key="$1"
+        [ -f /etc/environment ] && sed -i "/^${key}=/d" /etc/environment
+        [ -f /run/ra/env ] && sed -i "/^${key}=/d" /run/ra/env
+        return 0
+    }
+fi
+
 _clear_stale_state() {
     # Drop any prior auth state so switching providers doesn't leave
     # OPENAI_API_KEY set alongside a cached ChatGPT login (see openai/codex
-    # issue #20099 — silent fallback to API-key billing).
-    # Guard the sed calls: a fresh image may not have /etc/environment yet,
-    # and `sed -i` on a missing file fails, which under `set -e` aborts the
-    # whole setup before any auth is configured.
-    if [ -f /etc/environment ]; then
-        sed -i '/^OPENAI_API_KEY=/d'      /etc/environment
-        sed -i '/^CODEX_AUTH_JSON_B64=/d' /etc/environment
-    fi
+    # issue #20099 — silent fallback to API-key billing). Clearing through the
+    # helper drops the keys from BOTH /etc/environment and /run/ra/env, so a
+    # stale value can't linger where login shells still source it.
+    ra_env_unset OPENAI_API_KEY
+    ra_env_unset CODEX_AUTH_JSON_B64
     rm -f "${AUTH_FILE}"
 }
 
@@ -75,7 +95,7 @@ case "${RA_PLUGIN_CODEX_AUTH_PROVIDER:-}" in
         if [[ -z "${OPENAI_API_KEY:-}" ]]; then
             log "OPENAI_API_KEY not set; auth may fail"
         else
-            echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> /etc/environment
+            ra_env_set OPENAI_API_KEY "${OPENAI_API_KEY}"
             log "configured apikey mode"
         fi
         ;;

--- a/home/dot_config/ra/plugins/private_codex/workstation-startup.d/executable_260_codex-setup.sh
+++ b/home/dot_config/ra/plugins/private_codex/workstation-startup.d/executable_260_codex-setup.sh
@@ -26,24 +26,35 @@ AUTH_FILE="${CODEX_HOME}/auth.json"
 log() { echo "[codex-setup] $(date -u +%H:%M:%S) $*"; }
 
 # Source the shared ra-env helper (ra_env_set / ra_env_unset), installed by
-# 200_remote-agent-setup.sh at boot. Each function dedups and updates BOTH
-# /etc/environment and /run/ra/env. Fall back to a thin inline implementation
-# if the lib is missing (e.g. a newer plugin booting against an older core).
+# 200_remote-agent-setup.sh at boot. Each updates BOTH /etc/environment and
+# /run/ra/env, deduped. If the lib is somehow absent (e.g. a newer plugin
+# booting against an older core that predates it), fall back to an inline copy
+# with the SAME both-file contract — so behavior is identical whether or not the
+# lib is present, rather than silently diverging.
 if [ -r /usr/local/lib/ra/ra-env.sh ]; then
     # shellcheck source=/dev/null
     . /usr/local/lib/ra/ra-env.sh
 else
     log "WARNING: /usr/local/lib/ra/ra-env.sh missing; using inline fallback"
+    : "${RA_ENV_FILE:=/run/ra/env}"
     ra_env_set() {
         local key="$1" val="$2"
         [ -f /etc/environment ] || : > /etc/environment
         sed -i "/^${key}=/d" /etc/environment
         echo "${key}=${val}" >> /etc/environment
+        if [ ! -f "${RA_ENV_FILE}" ]; then
+            ( umask 077; : > "${RA_ENV_FILE}" )
+            chown user:user "${RA_ENV_FILE}"
+            chmod 0600 "${RA_ENV_FILE}"
+        fi
+        sed -i "/^${key}=/d" "${RA_ENV_FILE}"
+        local quoted="${val//\'/\'\\\'\'}"
+        printf "%s='%s'\n" "${key}" "${quoted}" >> "${RA_ENV_FILE}"
     }
     ra_env_unset() {
         local key="$1"
         [ -f /etc/environment ] && sed -i "/^${key}=/d" /etc/environment
-        [ -f /run/ra/env ] && sed -i "/^${key}=/d" /run/ra/env
+        [ -f "${RA_ENV_FILE}" ] && sed -i "/^${key}=/d" "${RA_ENV_FILE}"
         return 0
     }
 fi

--- a/home/dot_config/ra/plugins/private_gemini/workstation-startup.d/executable_260_gemini-setup.sh
+++ b/home/dot_config/ra/plugins/private_gemini/workstation-startup.d/executable_260_gemini-setup.sh
@@ -21,24 +21,35 @@ GEMINI_BIN_PATH="${USER_HOME}/.npm-global/bin/gemini"
 log() { echo "[gemini-setup] $(date -u +%H:%M:%S) $*"; }
 
 # Source the shared ra-env helper (ra_env_set / ra_env_unset), installed by
-# 200_remote-agent-setup.sh at boot. Each function dedups and updates BOTH
-# /etc/environment and /run/ra/env. Fall back to a thin inline implementation
-# if the lib is missing (e.g. a newer plugin booting against an older core).
+# 200_remote-agent-setup.sh at boot. Each updates BOTH /etc/environment and
+# /run/ra/env, deduped. If the lib is somehow absent (e.g. a newer plugin
+# booting against an older core that predates it), fall back to an inline copy
+# with the SAME both-file contract — so behavior is identical whether or not the
+# lib is present, rather than silently diverging.
 if [ -r /usr/local/lib/ra/ra-env.sh ]; then
     # shellcheck source=/dev/null
     . /usr/local/lib/ra/ra-env.sh
 else
     log "WARNING: /usr/local/lib/ra/ra-env.sh missing; using inline fallback"
+    : "${RA_ENV_FILE:=/run/ra/env}"
     ra_env_set() {
         local key="$1" val="$2"
         [ -f /etc/environment ] || : > /etc/environment
         sed -i "/^${key}=/d" /etc/environment
         echo "${key}=${val}" >> /etc/environment
+        if [ ! -f "${RA_ENV_FILE}" ]; then
+            ( umask 077; : > "${RA_ENV_FILE}" )
+            chown user:user "${RA_ENV_FILE}"
+            chmod 0600 "${RA_ENV_FILE}"
+        fi
+        sed -i "/^${key}=/d" "${RA_ENV_FILE}"
+        local quoted="${val//\'/\'\\\'\'}"
+        printf "%s='%s'\n" "${key}" "${quoted}" >> "${RA_ENV_FILE}"
     }
     ra_env_unset() {
         local key="$1"
         [ -f /etc/environment ] && sed -i "/^${key}=/d" /etc/environment
-        [ -f /run/ra/env ] && sed -i "/^${key}=/d" /run/ra/env
+        [ -f "${RA_ENV_FILE}" ] && sed -i "/^${key}=/d" "${RA_ENV_FILE}"
         return 0
     }
 fi

--- a/home/dot_config/ra/plugins/private_gemini/workstation-startup.d/executable_260_gemini-setup.sh
+++ b/home/dot_config/ra/plugins/private_gemini/workstation-startup.d/executable_260_gemini-setup.sh
@@ -20,15 +20,36 @@ GEMINI_BIN_PATH="${USER_HOME}/.npm-global/bin/gemini"
 
 log() { echo "[gemini-setup] $(date -u +%H:%M:%S) $*"; }
 
+# Source the shared ra-env helper (ra_env_set / ra_env_unset), installed by
+# 200_remote-agent-setup.sh at boot. Each function dedups and updates BOTH
+# /etc/environment and /run/ra/env. Fall back to a thin inline implementation
+# if the lib is missing (e.g. a newer plugin booting against an older core).
+if [ -r /usr/local/lib/ra/ra-env.sh ]; then
+    # shellcheck source=/dev/null
+    . /usr/local/lib/ra/ra-env.sh
+else
+    log "WARNING: /usr/local/lib/ra/ra-env.sh missing; using inline fallback"
+    ra_env_set() {
+        local key="$1" val="$2"
+        [ -f /etc/environment ] || : > /etc/environment
+        sed -i "/^${key}=/d" /etc/environment
+        echo "${key}=${val}" >> /etc/environment
+    }
+    ra_env_unset() {
+        local key="$1"
+        [ -f /etc/environment ] && sed -i "/^${key}=/d" /etc/environment
+        [ -f /run/ra/env ] && sed -i "/^${key}=/d" /run/ra/env
+        return 0
+    }
+fi
+
 _clear_stale_state() {
-    # Guard the seds: `sed -i` on a not-yet-created /etc/environment fails and,
-    # under `set -e`, would abort the whole setup before auth is configured.
-    if [ -f /etc/environment ]; then
-        sed -i '/^GEMINI_API_KEY=/d' /etc/environment
-        sed -i '/^GOOGLE_GENAI_USE_VERTEXAI=/d' /etc/environment
-        sed -i '/^GOOGLE_CLOUD_PROJECT=/d' /etc/environment
-        sed -i '/^GOOGLE_CLOUD_LOCATION=/d' /etc/environment
-    fi
+    # Clear prior auth from BOTH /etc/environment and /run/ra/env so a provider
+    # switch can't leave stale values where login shells still source them.
+    ra_env_unset GEMINI_API_KEY
+    ra_env_unset GOOGLE_GENAI_USE_VERTEXAI
+    ra_env_unset GOOGLE_CLOUD_PROJECT
+    ra_env_unset GOOGLE_CLOUD_LOCATION
 
     if [[ -f "${GEMINI_SETTINGS_PATH}" ]] && command -v jq >/dev/null 2>&1; then
         # A pre-existing corrupt/empty settings.json makes jq fail; the bare
@@ -101,7 +122,7 @@ case "${RA_PLUGIN_GEMINI_AUTH_PROVIDER:-}" in
         if [[ -z "${GEMINI_API_KEY:-}" ]]; then
             log "GEMINI_API_KEY not set; auth may fail"
         else
-            echo "GEMINI_API_KEY=${GEMINI_API_KEY}" >> /etc/environment
+            ra_env_set GEMINI_API_KEY "${GEMINI_API_KEY}"
             log "exported GEMINI_API_KEY"
             _write_settings "USE_GEMINI"
             _smoke_test "GEMINI_API_KEY=${GEMINI_API_KEY}"
@@ -111,11 +132,9 @@ case "${RA_PLUGIN_GEMINI_AUTH_PROVIDER:-}" in
         : "${GCP_PROJECT_ID:?GCP_PROJECT_ID not set — required for vertex auth}"
         region="${RA_PLUGIN_GEMINI_REGION:-us-central1}"
         [ -n "${region}" ] || region="us-central1"
-        {
-            echo "GOOGLE_GENAI_USE_VERTEXAI=true"
-            echo "GOOGLE_CLOUD_PROJECT=${GCP_PROJECT_ID}"
-            echo "GOOGLE_CLOUD_LOCATION=${region}"
-        } >> /etc/environment
+        ra_env_set GOOGLE_GENAI_USE_VERTEXAI true
+        ra_env_set GOOGLE_CLOUD_PROJECT "${GCP_PROJECT_ID}"
+        ra_env_set GOOGLE_CLOUD_LOCATION "${region}"
         log "configured Vertex AI mode (project=${GCP_PROJECT_ID}, location=${region})"
         _write_settings "USE_VERTEX_AI"
         _smoke_test \

--- a/home/dot_config/ra/workstation-startup.d/executable_200_remote-agent-setup.sh
+++ b/home/dot_config/ra/workstation-startup.d/executable_200_remote-agent-setup.sh
@@ -36,34 +36,63 @@ log() {
     echo "${msg}" >> "${RA_SETUP_LOG_PATH}" 2>/dev/null || true
 }
 
-# _ra_export_env writes a key=value pair to both /etc/environment and
-# /run/ra/env (creating the latter lazily). Both files are deduped per-key
-# so repeat calls (or repeat boots) don't accumulate stale entries.
-# Keys are valid env var names ([A-Za-z_][A-Za-z0-9_]*), so the sed regex
-# is safe without escaping.
-_ra_export_env() {
+# Install the shared ra-env helper library, then source it. Plugin scripts
+# (workstation-startup.d/ at numbers >= 250) run as SEPARATE processes and
+# source this same file, so env-var persistence — per-key dedup, the dual write
+# to /etc/environment and /run/ra/env, and the /run/ra/env quoting — lives in
+# exactly one place. Emitted with a single-quoted heredoc (<<'RA_ENV_LIB') so
+# the escaping expressions below are written to the file literally, not expanded
+# here. This script sources its own emitted lib so there is no duplicated body.
+install -d -m 0755 /usr/local/lib/ra
+cat > /usr/local/lib/ra/ra-env.sh <<'RA_ENV_LIB'
+#!/bin/bash
+# ra-env helper library — installed by 200_remote-agent-setup.sh; sourced by the
+# core setup script and by plugin workstation-startup.d scripts.
+#
+#   ra_env_set KEY VALUE  — dedup + write KEY to BOTH /etc/environment (literal,
+#                           pam_env-parsed) and /run/ra/env (single-quote
+#                           escaped, bash-sourced by login shells). Creates
+#                           /run/ra/env lazily, owned user:user 0600.
+#   ra_env_unset KEY      — remove KEY from BOTH files. Idempotent; set -e safe.
+#
+# Keys are valid env var names ([A-Za-z_][A-Za-z0-9_]*), so the sed regexes are
+# safe without escaping. Plugins don't set RA_ENV_FILE, so default it here.
+: "${RA_ENV_FILE:=/run/ra/env}"
+
+ra_env_set() {
     local key="$1"
     local val="$2"
-    [[ -f /etc/environment ]] || : > /etc/environment
+    [ -f /etc/environment ] || : > /etc/environment
     sed -i "/^${key}=/d" /etc/environment
     echo "${key}=${val}" >> /etc/environment
-    umask 077
-    if [[ ! -f "${RA_ENV_FILE}" ]]; then
-        : > "${RA_ENV_FILE}"
-        # This file holds fetched secret values (OAuth tokens, API keys). The
-        # workstation `user` login shell sources it via profile.d/00-ra-wait.sh,
-        # so it must be readable by `user` but NOT world-readable. Own it by
-        # `user` at 0600 (root, the writer, can read it regardless).
+    if [ ! -f "${RA_ENV_FILE}" ]; then
+        # Create 0600 from the start. The umask is scoped to a subshell so it
+        # can't leak into a sourcing plugin's shell and tighten files that
+        # plugin creates afterward. Holds fetched secret values (OAuth tokens,
+        # API keys); the `user` login shell sources it via
+        # profile.d/00-ra-wait.sh, so own it by `user` (root, the writer, can
+        # read it regardless).
+        ( umask 077; : > "${RA_ENV_FILE}" )
         chown user:user "${RA_ENV_FILE}"
         chmod 0600 "${RA_ENV_FILE}"
     fi
     sed -i "/^${key}=/d" "${RA_ENV_FILE}"
-    # /run/ra/env is bash-sourced via `set -a; . FILE`. Single-quote-wrap (with
-    # embedded-quote escaping `'\''`) so values containing spaces or shell
-    # metacharacters can't be re-parsed as extra commands during sourcing.
+    # Single-quote-wrap (with embedded-quote escaping `'\''`) so values with
+    # spaces or shell metacharacters can't be re-parsed during sourcing.
     local quoted="${val//\'/\'\\\'\'}"
     printf "%s='%s'\n" "${key}" "${quoted}" >> "${RA_ENV_FILE}"
 }
+
+ra_env_unset() {
+    local key="$1"
+    [ -f /etc/environment ] && sed -i "/^${key}=/d" /etc/environment
+    [ -f "${RA_ENV_FILE}" ] && sed -i "/^${key}=/d" "${RA_ENV_FILE}"
+    return 0
+}
+RA_ENV_LIB
+chmod 0644 /usr/local/lib/ra/ra-env.sh
+# shellcheck source=/dev/null
+. /usr/local/lib/ra/ra-env.sh
 
 
 : > "${RA_SETUP_LOG_PATH}" 2>/dev/null || true
@@ -106,7 +135,7 @@ for logical in "${ra_secret_names[@]}"; do
         --secret="${secret_name}" --project="${GCP_PROJECT_ID}" \
         2> >(while read -r line; do log "gcloud: ${line}"; done) || true)
     if [[ -n "${val}" ]]; then
-        _ra_export_env "${target_env_var}" "${val}"
+        ra_env_set "${target_env_var}" "${val}"
         log "Exported ${target_env_var} via /etc/environment and ${RA_ENV_FILE}."
     else
         log "WARNING: ${secret_name} fetch returned empty."
@@ -135,7 +164,7 @@ if [[ -n "${RA_PROPAGATE_KEYS:-}" ]]; then
     for _key in "${_ra_propagate_keys[@]}"; do
         [[ -z "${_key}" ]] && continue
         _val="${!_key:-}"
-        _ra_export_env "${_key}" "${_val}"
+        ra_env_set "${_key}" "${_val}"
         log "Propagated ${_key} via /etc/environment and ${RA_ENV_FILE}."
     done
     unset _ra_propagate_keys _key _val


### PR DESCRIPTION
Mirrors the upstream refactor (remote-agent #142 + ra-plugins) into the chezmoi-managed `~/.config/ra` snapshot: `200` emits and sources `/usr/local/lib/ra/ra-env.sh`; the claude/codex/gemini setup scripts call `ra_env_set`/`ra_env_unset` instead of writing `/etc/environment` by hand.

Snapshot-only; verified byte-identical to the upstream sources. Live `~/.config/ra` updates after merge + `chezmoi update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)