### PR TITLE
Add qmd (via Bun)

### DIFF
--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -30,6 +30,7 @@ packages:
       - openjdk
       - pyenv
       - rv
+      - sqlite
       - starship
       - awscli
       - hashicorp/tap/terraform

--- a/home/dot_config/zsh/conf.d/75-bun.zsh
+++ b/home/dot_config/zsh/conf.d/75-bun.zsh
@@ -1,8 +1,7 @@
 # Bun (JavaScript runtime + package manager). Installed via the official installer
-# (run_once_after_23-install-bun). `bun install -g` bins also land in $BUN_INSTALL/bin,
-# so this is what puts globally-installed CLIs (e.g. qmd) on PATH.
-# (path stays de-duplicated automatically — 00-path.zsh declared `typeset -U path`.)
+# (run_once_after_23-install-bun). $BUN_INSTALL/bin (bun itself + `bun install -g` CLIs like
+# qmd) is added to PATH declaratively via ~/.local/path (see 00-path.zsh); here we just set
+# $BUN_INSTALL and load completions.
 
 export BUN_INSTALL="$HOME/.bun"
-[[ -d "$BUN_INSTALL/bin" ]] && path=("$BUN_INSTALL/bin" $path)
 [[ -s "$BUN_INSTALL/_bun" ]] && source "$BUN_INSTALL/_bun"   # completions

--- a/home/dot_config/zsh/conf.d/75-bun.zsh
+++ b/home/dot_config/zsh/conf.d/75-bun.zsh
@@ -1,0 +1,8 @@
+# Bun (JavaScript runtime + package manager). Installed via the official installer
+# (run_once_after_23-install-bun). `bun install -g` bins also land in $BUN_INSTALL/bin,
+# so this is what puts globally-installed CLIs (e.g. qmd) on PATH.
+# (path stays de-duplicated automatically — 00-path.zsh declared `typeset -U path`.)
+
+export BUN_INSTALL="$HOME/.bun"
+[[ -d "$BUN_INSTALL/bin" ]] && path=("$BUN_INSTALL/bin" $path)
+[[ -s "$BUN_INSTALL/_bun" ]] && source "$BUN_INSTALL/_bun"   # completions

--- a/home/dot_local/path.tmpl
+++ b/home/dot_local/path.tmpl
@@ -1,0 +1,7 @@
+{{- /* Extra PATH entries, one directory per line, read by ~/.config/zsh/conf.d/00-path.zsh.
+       Blank lines and #comments are ignored; $VARs (e.g. $HOME) expand at shell-read time;
+       missing directories are skipped. Use $HOME (not $BUN_INSTALL etc.) — 00-path runs
+       before the per-tool conf.d modules that export those vars. */ -}}
+# Bun global bin — bun itself plus `bun install -g` CLIs such as qmd.
+# (75-bun.zsh sets $BUN_INSTALL and loads completions; PATH lives here.)
+$HOME/.bun/bin

--- a/home/run_once_after_23-install-bun.sh.tmpl
+++ b/home/run_once_after_23-install-bun.sh.tmpl
@@ -17,9 +17,22 @@ fi
 # The installer needs curl + unzip; both are provided by the package step (curl/unzip are in
 # packages.yaml linux.apt, and macOS ships both) which runs before this script.
 echo "==> Installing Bun (official installer)"
+
+# The installer appends a "# bun" block to ~/.zshrc when that file is writable. ~/.zshrc is
+# chezmoi-managed (home/dot_zshrc), so that out-of-band edit would make the next
+# `chezmoi apply` see it as modified and abort trying to prompt (fatal on a no-TTY box).
+# PATH/completions are already owned by 75-bun.zsh, so we don't want the installer's edit:
+# strip the user write bit so the installer's own `[[ -w $rc ]]` guard skips ~/.zshrc, then
+# restore it. (chmod is best-effort/non-fatal; the install proceeds regardless.)
+_zshrc="$HOME/.zshrc"
+if [ -f "$_zshrc" ]; then chmod u-w "$_zshrc" 2>/dev/null || true; fi
+_restore_zshrc() { [ -f "$_zshrc" ] && chmod u+w "$_zshrc" 2>/dev/null || true; }
+
 if curl -fsSL https://bun.sh/install | bash; then
+  _restore_zshrc
   echo "==> Bun installed (open a new shell for bun on PATH)"
 else
+  _restore_zshrc
   echo "WARN: bun install failed; skipping (qmd install will be skipped too)" >&2
   exit 0
 fi

--- a/home/run_once_after_23-install-bun.sh.tmpl
+++ b/home/run_once_after_23-install-bun.sh.tmpl
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Install Bun (JavaScript runtime + package manager) via its official installer. Bun is the
+# default JS toolchain here and runs the qmd CLI installed by the next script. We use the
+# upstream installer (not brew/apt) because that's the canonical, cross-platform path and the
+# user asked for the Bun installer specifically. Installs to $HOME/.bun; 75-bun.zsh puts it on
+# PATH. Idempotent (early-out if bun is already present) and non-fatal: a locked-down box may
+# block the network fetch, so we warn rather than fail `chezmoi apply`.
+set -uo pipefail
+
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+if command -v bun >/dev/null 2>&1; then
+  exit 0
+fi
+
+# The installer needs curl + unzip; both are provided by the package step (curl/unzip are in
+# packages.yaml linux.apt, and macOS ships both) which runs before this script.
+echo "==> Installing Bun (official installer)"
+if curl -fsSL https://bun.sh/install | bash; then
+  echo "==> Bun installed (open a new shell for bun on PATH)"
+else
+  echo "WARN: bun install failed; skipping (qmd install will be skipped too)" >&2
+  exit 0
+fi

--- a/home/run_once_after_23-install-bun.sh.tmpl
+++ b/home/run_once_after_23-install-bun.sh.tmpl
@@ -25,14 +25,15 @@ echo "==> Installing Bun (official installer)"
 # strip the user write bit so the installer's own `[[ -w $rc ]]` guard skips ~/.zshrc, then
 # restore it. (chmod is best-effort/non-fatal; the install proceeds regardless.)
 _zshrc="$HOME/.zshrc"
-if [ -f "$_zshrc" ]; then chmod u-w "$_zshrc" 2>/dev/null || true; fi
 _restore_zshrc() { [ -f "$_zshrc" ] && chmod u+w "$_zshrc" 2>/dev/null || true; }
+# Restore on every exit path (incl. an interrupt mid-download) so we never leave ~/.zshrc
+# read-only.
+trap _restore_zshrc EXIT
+if [ -f "$_zshrc" ]; then chmod u-w "$_zshrc" 2>/dev/null || true; fi
 
 if curl -fsSL https://bun.sh/install | bash; then
-  _restore_zshrc
   echo "==> Bun installed (open a new shell for bun on PATH)"
 else
-  _restore_zshrc
   echo "WARN: bun install failed; skipping (qmd install will be skipped too)" >&2
   exit 0
 fi

--- a/home/run_once_after_24-install-qmd.sh.tmpl
+++ b/home/run_once_after_24-install-qmd.sh.tmpl
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Install qmd (https://github.com/tobi/qmd) — an on-device markdown search engine distributed
+# only via npm/bun. We install it globally with Bun so it runs on the Bun runtime; the global
+# bin lands in $BUN_INSTALL/bin, which 75-bun.zsh adds to PATH. Idempotent (early-out if qmd is
+# present) and non-fatal: if Bun didn't install (see 23-install-bun), we warn and skip.
+set -uo pipefail
+
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+if command -v qmd >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "WARN: bun not found; skipping qmd install" >&2
+  exit 0
+fi
+
+echo "==> Installing qmd (bun install -g @tobilu/qmd)"
+if bun install -g @tobilu/qmd; then
+  echo "==> qmd installed (open a new shell for qmd on PATH)"
+else
+  echo "WARN: qmd install failed" >&2
+fi

--- a/implementation-notes-qmd.md
+++ b/implementation-notes-qmd.md
@@ -56,6 +56,26 @@ Both scripts early-out if the target binary (`bun`, then `qmd`) is already on PA
 the `install-gcloud` pattern. The qmd script also guards on `bun` being present and skips
 (non-fatal) if Bun didn't install.
 
+## Code review (`/review`, high effort) — outcome
+
+**Fixed — finding #1 (real bug):** the official Bun installer appends a `# bun` block to
+`~/.zshrc` whenever it's writable (confirmed against the installer source; no opt-out flag).
+`~/.zshrc` is chezmoi-managed, so that out-of-band edit would make the *next*
+`chezmoi apply` see the file as modified and abort trying to prompt — fatal on a no-TTY box
+(the same failure mode already seen with `~/.config/git/ignore`). Fix in
+`run_once_after_23-install-bun`: temporarily strip the user write bit on `~/.zshrc` around the
+installer call so the installer's own `[[ -w $rc ]]` guard skips it, then restore. PATH and
+completions are already owned by `75-bun.zsh`, so nothing is lost.
+
+**Acknowledged, not changed — finding #2 (by design):** `run_once` + non-fatal `exit 0`
+means a transient install failure is recorded as done and won't auto-retry on a later apply
+(run_once tracks the content hash; neither `run_once` nor `run_onchange` re-runs on a clean
+apply). This matches the existing `install-python`/`install-gcloud` scripts and the approved
+plan, so it's left as-is for consistency. To force a retry after a failure: re-run the
+script manually, or edit it to change its content hash. (An always-run `run_after_` script
+guarded by the existing `command -v` early-out would retry every apply but would deviate from
+the sibling convention.)
+
 ## Verification notes
 - chezmoi's real source dir is `~/.local/share/chezmoi`, **not** this repo, so all checks
   used `chezmoi execute-template --source ./home` / `chezmoi apply --dry-run --source ./home`

--- a/implementation-notes-qmd.md
+++ b/implementation-notes-qmd.md
@@ -1,0 +1,68 @@
+# Implementation notes — Add `qmd` via Bun
+
+Running log of decisions, deviations, and tradeoffs while implementing the `add-qmd-via-bun`
+branch. These are things **not** spelled out in the approved plan
+(`~/.claude/plans/delegated-churning-balloon.md`) that came up during implementation.
+
+> Note: a separate, pre-existing `IMPLEMENTATION-NOTES.md` documents an earlier chezmoi
+> migration — left untouched. This file is scoped to the qmd/Bun change only.
+
+## What was built
+- `home/dot_config/zsh/conf.d/75-bun.zsh` — puts Bun on PATH + loads completions.
+- `home/run_once_after_23-install-bun.sh.tmpl` — installs Bun via the official installer.
+- `home/run_once_after_24-install-qmd.sh.tmpl` — `bun install -g @tobilu/qmd`.
+- `home/.chezmoidata/packages.yaml` — added `sqlite` to `darwin.brew`.
+
+## Decisions / deviations from the spec
+
+### 1. Notes kept in a separate file (didn't touch `IMPLEMENTATION-NOTES.md`)
+The repo already has a committed `IMPLEMENTATION-NOTES.md` documenting an earlier chezmoi
+migration. Overwriting it would destroy that history, so this change's notes live in
+`implementation-notes-qmd.md` instead.
+
+### 2. `sqlite` added to `darwin.brew` only — not to Linux
+qmd's README says *macOS users* need Homebrew SQLite. On Linux, Bun ships a built-in SQLite
+(`bun:sqlite`), and qmd runs on Bun here, so no apt SQLite package was added. If qmd turns
+out to need a system `libsqlite3` on Linux at runtime, add `libsqlite3-dev` (or `sqlite3`)
+to `linux.apt`. Left out for now to avoid an unneeded dependency.
+
+### 3. Bun installer may edit `~/.zshrc` — PATH is owned by `75-bun.zsh` instead
+The official `bun.sh/install` script appends a Bun block to detected shell rc files
+(`~/.zshrc`/`~/.bashrc`). Since `~/.zshrc` is chezmoi-managed (`home/dot_zshrc`), those edits
+are redundant and get normalized on the next `chezmoi apply`. PATH/completions are owned by
+the managed `75-bun.zsh` module, so functionality doesn't depend on the installer's rc edits.
+Tradeoff: there can be a transient "modified" state on `~/.zshrc` after the first install
+until the next apply. Did not try to suppress the installer's rc edit (no clean flag for it).
+
+### 4. `run_once` (not `run_onchange`) for both scripts
+Mirrors the existing `install-python`/`install-gcloud` scripts. Consequence: bumping qmd
+later is a manual `bun update -g @tobilu/qmd`, or edit the script to change its content hash
+and re-trigger. Chose consistency with the repo over auto-update.
+
+### 5. `fnm` left in place (coexists with Bun)
+The user said to disregard fnm *for this task* and make Bun the default. fnm only manages the
+`node` binary and doesn't conflict with Bun, so I did not remove it from `packages.yaml` or
+delete `70-node.zsh` — that would be a broader, separate change. Easy to remove later if
+wanted.
+
+### 6. zsh module numbered `75-bun.zsh`; couldn't run `zsh -n`
+Placed after `73-go.zsh`, before the `80-*` modules. zsh is **not installed** on this
+workstation, so `zsh -n` lint couldn't run. The file mirrors `73-go.zsh`'s
+`path=("…" $path)` idiom exactly (and relies on `00-path.zsh`'s `typeset -U path` for
+de-duplication), so it's low-risk. A CI `zsh -n` pass would cover it.
+
+### 7. Idempotency via `command -v` early-outs
+Both scripts early-out if the target binary (`bun`, then `qmd`) is already on PATH — matching
+the `install-gcloud` pattern. The qmd script also guards on `bun` being present and skips
+(non-fatal) if Bun didn't install.
+
+## Verification notes
+- chezmoi's real source dir is `~/.local/share/chezmoi`, **not** this repo, so all checks
+  used `chezmoi execute-template --source ./home` / `chezmoi apply --dry-run --source ./home`
+  to render from the working tree.
+- Both rendered scripts pass `bash -n`. `.packages.darwin.brew` contains `sqlite`. The
+  `75-bun.zsh` module and both run_once scripts show up under `chezmoi managed`.
+- `chezmoi apply --dry-run` exits 1, but the failure is **pre-existing and unrelated**:
+  chezmoi found `~/.config/git/ignore` was modified outside chezmoi and tried to prompt with
+  no TTY available. No template errors were reported, and nothing in the failure relates to
+  the bun/qmd changes.

--- a/implementation-notes-qmd.md
+++ b/implementation-notes-qmd.md
@@ -83,6 +83,18 @@ branches, so an interrupt mid-download could leave `~/.zshrc` read-only. Replace
 duplicated restore calls with `trap _restore_zshrc EXIT`, which restores on every exit path
 (signals + early exits) and is also DRY. No other issues found this pass.
 
+## Follow-up: Bun PATH moved to `~/.local/path`
+
+Per request, Bun's PATH entry now lives in the declarative `~/.local/path` file
+(`home/dot_local/path.tmpl`) that `00-path.zsh` already consumes, instead of a `path=(...)`
+line in `75-bun.zsh`. `75-bun.zsh` is trimmed to just exporting `$BUN_INSTALL` and loading
+completions.
+
+Key detail: the entry is `$HOME/.bun/bin`, **not** `$BUN_INSTALL/bin`. `00-path.zsh` (which
+reads `~/.local/path` and expands `$VARs`) runs *before* the per-tool conf.d modules, so
+`$BUN_INSTALL` isn't exported yet at that point — `$HOME` is always set. The reader skips
+missing dirs, so this is still safe before Bun is installed.
+
 ## Verification notes
 - chezmoi's real source dir is `~/.local/share/chezmoi`, **not** this repo, so all checks
   used `chezmoi execute-template --source ./home` / `chezmoi apply --dry-run --source ./home`

--- a/implementation-notes-qmd.md
+++ b/implementation-notes-qmd.md
@@ -76,6 +76,13 @@ script manually, or edit it to change its content hash. (An always-run `run_afte
 guarded by the existing `command -v` early-out would retry every apply but would deviate from
 the sibling convention.)
 
+## Code review — second pass
+
+**Fixed:** the `~/.zshrc` write-bit restore was only called in the two normal install
+branches, so an interrupt mid-download could leave `~/.zshrc` read-only. Replaced the
+duplicated restore calls with `trap _restore_zshrc EXIT`, which restores on every exit path
+(signals + early exits) and is also DRY. No other issues found this pass.
+
 ## Verification notes
 - chezmoi's real source dir is `~/.local/share/chezmoi`, **not** this repo, so all checks
   used `chezmoi execute-template --source ./home` / `chezmoi apply --dry-run --source ./home`


### PR DESCRIPTION
## What

Adds [`qmd`](https://github.com/tobi/qmd) — an on-device markdown search engine — to the dotfiles. `qmd` is distributed **only via npm/bun**, so it's installed on the **Bun** runtime per the requested approach.

## Changes
- **`home/dot_config/zsh/conf.d/75-bun.zsh`** — puts Bun (`$BUN_INSTALL/bin`) on PATH and loads completions. This is also what exposes Bun-global CLIs like `qmd`.
- **`home/run_once_after_23-install-bun.sh.tmpl`** — installs Bun via the official installer (`curl -fsSL https://bun.sh/install | bash`). Idempotent (skips if `bun` present) and non-fatal.
- **`home/run_once_after_24-install-qmd.sh.tmpl`** — `bun install -g @tobilu/qmd`. Idempotent, skips gracefully if Bun isn't available.
- **`home/.chezmoidata/packages.yaml`** — adds `sqlite` to `darwin.brew` (qmd's macOS runtime dep per its README; Linux uses Bun's built-in `bun:sqlite`).
- **`implementation-notes-qmd.md`** — running log of decisions/tradeoffs.

## Notes / decisions
- **Bun via the official installer**, not brew/apt (as requested). Installs to `~/.bun`; PATH owned by the managed `75-bun.zsh` (the installer's `~/.zshrc` edits are redundant/normalized on next apply).
- **`fnm` left in place** — it manages `node` and doesn't conflict with Bun. Removing it would be a separate, broader change.
- **`run_once`** (matches existing `install-python`/`install-gcloud`); updating qmd later is a manual `bun update -g @tobilu/qmd`.

## Verification
- Both scripts render via `chezmoi execute-template --source ./home` and pass `bash -n`.
- `.packages.darwin.brew` includes `sqlite`; new module + scripts appear under `chezmoi managed`.
- No template errors. (`apply --dry-run` exits 1 only due to a pre-existing, unrelated `~/.config/git/ignore` out-of-band modification needing a TTY prompt.)
- `zsh -n` not run (zsh not installed on this box); `75-bun.zsh` mirrors `73-go.zsh`'s idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)