### PR TITLE
Fix CI: invalid YAML in doctor step broke whole workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
           EOF
 
       - name: doctor
-        run: "$HOME/.local/bin/chezmoi doctor --source ./home" || true
+        run: |
+          "$HOME/.local/bin/chezmoi" doctor --source ./home || true
 
       - name: Render whole tree (dry-run apply — does not run scripts)
         run: "$HOME/.local/bin/chezmoi apply --source ./home --dry-run --verbose"


### PR DESCRIPTION
## Problem

Every `chezmoi` CI run has failed since the workflow was added — on `main` and every feature branch — dying in **0s with zero jobs** and GitHub's *"This run likely failed because of a workflow file issue."* That signature (instant failure, no jobs, fires even on branches the `on:` filter should exclude) means GitHub could not parse the workflow file at all, so it couldn't apply the branch filter and logged a failed run on every push.

## Root cause

`.github/workflows/ci.yml`, the `doctor` step:

```yaml
run: "$HOME/.local/bin/chezmoi doctor --source ./home" || true
```

A double-quoted YAML scalar followed by trailing `|| true` is illegal — the parser reads the first `|` of `||` as a block-scalar indicator and errors (`ScannerError ... line 37 ... found '|'`). That single line made the **entire file** unparseable, which is why all four matrix jobs never started.

## Fix

Convert the step to a `run: |` block scalar (matching the lint step's style), preserving the non-fatal `|| true`:

```yaml
- name: doctor
  run: |
    "$HOME/.local/bin/chezmoi" doctor --source ./home || true
```

Verified locally: the file now parses cleanly and `on:` resolves as intended.

## Note

This was a single root cause — no CI step had ever executed, so no other failures were hidden in the logs. Once merged, the workflow runs for the first time; watch that first run for any real `chezmoi apply --dry-run` render errors, and note the `macos-latest` matrix consumes Actions minutes at 10x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)