### PR TITLE
fix(ra): single-quote-wrap /etc/environment in inline fallback

### DIFF
--- a/home/dot_config/ra/plugins/private_claude/workstation-startup.d/executable_260_claude-setup.sh
+++ b/home/dot_config/ra/plugins/private_claude/workstation-startup.d/executable_260_claude-setup.sh
@@ -36,16 +36,16 @@ else
     : "${RA_ENV_FILE:=/run/ra/env}"
     ra_env_set() {
         local key="$1" val="$2"
+        local quoted="${val//\'/\'\\\'\'}"
         [ -f /etc/environment ] || : > /etc/environment
         sed -i "/^${key}=/d" /etc/environment
-        echo "${key}=${val}" >> /etc/environment
+        printf "%s='%s'\n" "${key}" "${quoted}" >> /etc/environment
         if [ ! -f "${RA_ENV_FILE}" ]; then
             ( umask 077; : > "${RA_ENV_FILE}" )
             chown user:user "${RA_ENV_FILE}"
             chmod 0600 "${RA_ENV_FILE}"
         fi
         sed -i "/^${key}=/d" "${RA_ENV_FILE}"
-        local quoted="${val//\'/\'\\\'\'}"
         printf "%s='%s'\n" "${key}" "${quoted}" >> "${RA_ENV_FILE}"
     }
     ra_env_unset() {

--- a/home/dot_config/ra/plugins/private_codex/workstation-startup.d/executable_260_codex-setup.sh
+++ b/home/dot_config/ra/plugins/private_codex/workstation-startup.d/executable_260_codex-setup.sh
@@ -39,16 +39,16 @@ else
     : "${RA_ENV_FILE:=/run/ra/env}"
     ra_env_set() {
         local key="$1" val="$2"
+        local quoted="${val//\'/\'\\\'\'}"
         [ -f /etc/environment ] || : > /etc/environment
         sed -i "/^${key}=/d" /etc/environment
-        echo "${key}=${val}" >> /etc/environment
+        printf "%s='%s'\n" "${key}" "${quoted}" >> /etc/environment
         if [ ! -f "${RA_ENV_FILE}" ]; then
             ( umask 077; : > "${RA_ENV_FILE}" )
             chown user:user "${RA_ENV_FILE}"
             chmod 0600 "${RA_ENV_FILE}"
         fi
         sed -i "/^${key}=/d" "${RA_ENV_FILE}"
-        local quoted="${val//\'/\'\\\'\'}"
         printf "%s='%s'\n" "${key}" "${quoted}" >> "${RA_ENV_FILE}"
     }
     ra_env_unset() {

--- a/home/dot_config/ra/plugins/private_gemini/workstation-startup.d/executable_260_gemini-setup.sh
+++ b/home/dot_config/ra/plugins/private_gemini/workstation-startup.d/executable_260_gemini-setup.sh
@@ -34,16 +34,16 @@ else
     : "${RA_ENV_FILE:=/run/ra/env}"
     ra_env_set() {
         local key="$1" val="$2"
+        local quoted="${val//\'/\'\\\'\'}"
         [ -f /etc/environment ] || : > /etc/environment
         sed -i "/^${key}=/d" /etc/environment
-        echo "${key}=${val}" >> /etc/environment
+        printf "%s='%s'\n" "${key}" "${quoted}" >> /etc/environment
         if [ ! -f "${RA_ENV_FILE}" ]; then
             ( umask 077; : > "${RA_ENV_FILE}" )
             chown user:user "${RA_ENV_FILE}"
             chmod 0600 "${RA_ENV_FILE}"
         fi
         sed -i "/^${key}=/d" "${RA_ENV_FILE}"
-        local quoted="${val//\'/\'\\\'\'}"
         printf "%s='%s'\n" "${key}" "${quoted}" >> "${RA_ENV_FILE}"
     }
     ra_env_unset() {


### PR DESCRIPTION
## Summary
Follow-up to #21. The shared `ra-env` helper now single-quote-wraps `/etc/environment` values (mirrors remote-agent #141): some system tools shell-source `/etc/environment` under `set -e` — notably Debian's `update-info-dir` via the install-info dpkg trigger — where an unquoted value with shell metacharacters (e.g. a pipe-separated list) would misfire and break apt for any package shipping info files.

The plugin **inline fallback** `ra_env_set` (used only when the shared lib is somehow absent) still wrote `/etc/environment` raw with `echo`, diverging from the lib it's meant to mirror. This makes it match: both files now written with the same `printf` single-quote escaping.

## Scope
Snapshot-only, 3 files (claude/codex/gemini), 4 lines each. Verified byte-identical to the canonical sources (ra-plugins #10 + the local gemini copy). `bash -n` clean; the fallback's quoting was tested to round-trip a pipe-separated value safely through a shell-sourced `/etc/environment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)