### PR TITLE
Ensure chezmoi persists on PATH via run_once install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ sh -c "$(curl -fsSL https://get.chezmoi.io)" -- init --apply <your-github-userna
 You'll be asked to pick a **machine type**: `personal`, `work`, or `cloud-workstation`. The
 `cloud-workstation` choice skips GUI/macOS-only pieces (Hammerspoon, ghostty).
 
+The bootstrap binary chezmoi uses to apply may not persist on PATH afterward, so a `run_once`
+script (`run_once_after_10-install-chezmoi.sh.tmpl`) reinstalls chezmoi into `~/.local/bin`
+(always on PATH via `00-path.zsh`). To restore it manually:
+
+```sh
+sh -c "$(curl -fsSL https://get.chezmoi.io)" -- -b ~/.local/bin
+```
+
 ### Linux notes
 - Base packages come from `apt`; tools that apt lacks or ships stale (fnm, clojure, pyenv,
   starship, git-delta, awscli, terraform, pulumi) are installed via **Homebrew on Linux**, which

--- a/home/run_once_after_10-install-chezmoi.sh.tmpl
+++ b/home/run_once_after_10-install-chezmoi.sh.tmpl
@@ -19,7 +19,10 @@ echo "==> Installing chezmoi into $_bindir (official installer)"
 mkdir -p "$_bindir"
 
 # `-b <bindir>` tells the installer to drop only the binary (no init/apply) at that path.
-if sh -c "$(curl -fsSL https://get.chezmoi.io)" -- -b "$_bindir"; then
+# Pipe (not `sh -c "$(curl ...)"`) so `set -o pipefail` catches a failed fetch: command
+# substitution would swallow a network error into an empty script that exits 0, falsely
+# reporting success on the locked-down box this WARN path exists for.
+if curl -fsSL https://get.chezmoi.io | sh -s -- -b "$_bindir"; then
   echo "==> chezmoi installed (open a new shell for it on PATH)"
 else
   echo "WARN: chezmoi install failed; skipping (it stays available only via the bootstrap binary)" >&2

--- a/home/run_once_after_10-install-chezmoi.sh.tmpl
+++ b/home/run_once_after_10-install-chezmoi.sh.tmpl
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Install chezmoi itself into ~/.local/bin so it persists on PATH after bootstrap. The
+# get.chezmoi.io bootstrap one-liner fetches chezmoi to a temporary/cwd location just long
+# enough to run `init --apply`; once that finishes, `chezmoi` may not live in any PATH dir.
+# ~/.local/bin is unconditionally prepended to PATH by 00-path.zsh, and it's the documented
+# canonical home for this binary, so we ensure a copy lands there. Idempotent (early-out if
+# already present) and non-fatal: a locked-down box may block the network fetch, so we warn
+# rather than fail `chezmoi apply`. Cross-platform: the official installer and ~/.local/bin
+# both work on macOS and Linux.
+set -uo pipefail
+
+_bindir="$HOME/.local/bin"
+
+if [ -x "$_bindir/chezmoi" ]; then
+  exit 0
+fi
+
+echo "==> Installing chezmoi into $_bindir (official installer)"
+mkdir -p "$_bindir"
+
+# `-b <bindir>` tells the installer to drop only the binary (no init/apply) at that path.
+if sh -c "$(curl -fsSL https://get.chezmoi.io)" -- -b "$_bindir"; then
+  echo "==> chezmoi installed (open a new shell for it on PATH)"
+else
+  echo "WARN: chezmoi install failed; skipping (it stays available only via the bootstrap binary)" >&2
+  exit 0
+fi


### PR DESCRIPTION
## Problem

The `get.chezmoi.io` bootstrap one-liner fetches chezmoi to a temporary/cwd location only long enough to run `init --apply`. Afterward `chezmoi` may not live in any PATH directory — on this machine it was missing entirely, with only an untracked copy left in the dev checkout (`~/.dotfiles/bin/chezmoi`).

## Change

- **`home/run_once_after_10-install-chezmoi.sh.tmpl`** — reinstalls chezmoi into `~/.local/bin` (unconditionally prepended to PATH by `00-path.zsh`, and the documented canonical home for the binary). Idempotent (early-out if already present) and non-fatal (warns instead of failing `chezmoi apply` on a network-restricted box), matching the existing `run_once` install-script conventions (e.g. the bun script). Cross-platform; runs early (`10`).
- **`README.md`** — documents the script in the Bootstrap section plus a manual restore one-liner.

## Verification

- `bash -n` on the script passes (no template directives, so the shell lint is exact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)